### PR TITLE
multi-selection component insertion

### DIFF
--- a/extension/__init__.py
+++ b/extension/__init__.py
@@ -1,11 +1,13 @@
 import bpy # type: ignore
 import json
 from bpy.app.handlers import persistent
+from .op_insert_component_modal import InsertComponent, SelectedObjectOptions
 from .op_apply_preset import ApplyPresetToBone, ApplyPresetToCollection, ApplyPresetToLight, ApplyPresetToMaterial, ApplyPresetToMesh, ApplyPresetToObject, ApplyPresetToScene
 from .cli_dump_component_data import dump_component_data # type: ignore
-from .op_insert_component import InsertComponentOnBone, InsertComponentOnCollection, InsertComponentOnLight, InsertComponentOnMaterial, InsertComponentOnMesh, InsertComponentOnObject, InsertComponentOnScene
+from .op_insert_component import InsertComponentOnBone, InsertComponentOnCollection, InsertComponentOnLight, InsertComponentOnMaterial, InsertComponentOnMesh, InsertComponentOnObject, InsertComponentOnWindowManager, InsertComponentOnScene
+# from .op_insert_component_modal import InsertComponent
 from .op_registry_loading import FetchRemoteTypeRegistry, ReloadSkeinRegistryJson
-from .op_remove_component import RemoveComponentOnBone, RemoveComponentOnCollection, RemoveComponentOnLight, RemoveComponentOnMaterial, RemoveComponentOnMesh, RemoveComponentOnObject, RemoveComponentOnScene
+from .op_remove_component import RemoveComponentOnBone, RemoveComponentOnCollection, RemoveComponentOnLight, RemoveComponentOnMaterial, RemoveComponentOnMesh, RemoveComponentOnObject, RemoveComponentOnScene, RemoveComponentOnWindowManager
 from .op_debug_check_components import DebugCheckComponents
 from .property_groups import ComponentData
 from .skein_panel import SkeinPanelBone, SkeinPanelCollection, SkeinPanelLight, SkeinPanelObject, SkeinPanelMesh, SkeinPanelMaterial, SkeinPanelScene
@@ -92,6 +94,10 @@ def menu_func(self, context):
     self.layout.operator(ReloadSkeinRegistryJson.bl_idname)
 
 def register():
+    # TODO: move this
+    bpy.utils.register_class(SelectedObjectOptions)
+
+
     bpy.utils.register_class(SkeinAddonPreferences)
     # data types that are stored on the window because blender
     # doesn't seem to have any other good way of storing data
@@ -135,6 +141,11 @@ def register():
         override={"LIBRARY_OVERRIDABLE"},
     )
 
+    ## Used for temporary data, like operators
+    bpy.types.WindowManager.active_component_index = bpy.props.IntProperty(
+        min=0
+    )
+
     # TODO: move this to common property group for all object, material, mesh, etc extras
     bpy.types.WindowManager.selected_component = bpy.props.StringProperty(
         name="component type path",
@@ -150,6 +161,7 @@ def register():
     bpy.utils.register_class(FetchRemoteTypeRegistry)
     bpy.utils.register_class(ReloadSkeinRegistryJson)
     bpy.utils.register_class(DebugCheckComponents)
+    # bpy.utils.register_class(InsertComponent)
     ## Insertion Operations
     bpy.utils.register_class(InsertComponentOnObject)
     bpy.utils.register_class(InsertComponentOnMesh)
@@ -158,6 +170,8 @@ def register():
     bpy.utils.register_class(InsertComponentOnLight)
     bpy.utils.register_class(InsertComponentOnCollection)
     bpy.utils.register_class(InsertComponentOnBone)
+    bpy.utils.register_class(InsertComponentOnWindowManager)
+    bpy.utils.register_class(InsertComponent)
     ## Remove Operations
     bpy.utils.register_class(RemoveComponentOnObject)
     bpy.utils.register_class(RemoveComponentOnMesh)
@@ -166,6 +180,7 @@ def register():
     bpy.utils.register_class(RemoveComponentOnLight)
     bpy.utils.register_class(RemoveComponentOnCollection)
     bpy.utils.register_class(RemoveComponentOnBone)
+    bpy.utils.register_class(RemoveComponentOnWindowManager)
     ## Preset Operations
     bpy.utils.register_class(ApplyPresetToObject)
     bpy.utils.register_class(ApplyPresetToMesh)
@@ -207,6 +222,9 @@ def register():
     exporter_extension_layout_draw['Example glTF Extension'] = draw_export # Make sure to use the same name in unregister()
 
 def unregister():
+    # TODO: move this
+    bpy.utils.unregister_class(SelectedObjectOptions)
+
     global_skein = bpy.context.window_manager.skein
     skein_property_groups = bpy.context.window_manager.skein_property_groups
 
@@ -234,6 +252,7 @@ def unregister():
     bpy.utils.unregister_class(PGSkeinWindowProps)
     bpy.utils.unregister_class(ComponentTypeData)
     bpy.utils.unregister_class(ComponentData)
+    # bpy.utils.unregister_class(InsertComponent)
     # operations
     bpy.utils.unregister_class(FetchRemoteTypeRegistry)
     bpy.utils.unregister_class(ReloadSkeinRegistryJson)
@@ -244,12 +263,17 @@ def unregister():
     bpy.utils.unregister_class(InsertComponentOnMaterial)
     bpy.utils.unregister_class(InsertComponentOnLight)
     bpy.utils.unregister_class(InsertComponentOnCollection)
+    bpy.utils.unregister_class(InsertComponentOnWindowManager)
+    bpy.utils.unregister_class(InsertComponent)
     ## Remove Operations
     bpy.utils.unregister_class(RemoveComponentOnObject)
     bpy.utils.unregister_class(RemoveComponentOnMesh)
     bpy.utils.unregister_class(RemoveComponentOnMaterial)
+    bpy.utils.unregister_class(RemoveComponentOnScene)
     bpy.utils.unregister_class(RemoveComponentOnLight)
     bpy.utils.unregister_class(RemoveComponentOnCollection)
+    bpy.utils.unregister_class(RemoveComponentOnBone)
+    bpy.utils.unregister_class(RemoveComponentOnWindowManager)
     ## Preset Operations
     bpy.utils.unregister_class(ApplyPresetToObject)
     bpy.utils.unregister_class(ApplyPresetToMesh)

--- a/extension/object_to_form.py
+++ b/extension/object_to_form.py
@@ -7,7 +7,7 @@ def object_to_form(context, context_key, data):
     data is the component data
     """
     if context_key not in context:
-        return
+         return
     
     # The current PropertyGroup we're working with
     obj = getattr(context, context_key)

--- a/extension/op_insert_component.py
+++ b/extension/op_insert_component.py
@@ -102,10 +102,28 @@ class InsertComponentOnBone(bpy.types.Operator):
         insert_component_data(context, context.bone)
         return {'FINISHED'}
 
-def insert_component_data(context, obj):
+class InsertComponentOnWindowManager(bpy.types.Operator):
+    """Insert a component on the window manager"""
+    bl_idname = "wm.insert_component" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Add Component" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    # @classmethod
+    # def poll(cls, context):
+        # return context.bone is not None
+
+    def execute(self, context):
+        insert_component_data(context, context.window_manager)
+        return {'FINISHED'}
+
+def insert_component_data(context, obj, type_path_override=None):
     """
     Inserting data is super generic, the only difference is where we're inserting it.
     This is basically the same concept as Custom Properties which don't care what object they're on.
+
+    Inserts using context.window_manager.selected_component if a type_path_override isn't set
+
+    expects a full, raw type_path in type_path_override
     """
     debug = False
     presets = False
@@ -118,7 +136,7 @@ def insert_component_data(context, obj):
         print("\ninsert_component_data:")
     
     global_skein = context.window_manager.skein
-    selected_component = context.window_manager.selected_component
+    selected_component = type_path_override or context.window_manager.selected_component
 
     if global_skein.registry:
         registry = json.loads(global_skein.registry)

--- a/extension/op_insert_component_modal.py
+++ b/extension/op_insert_component_modal.py
@@ -1,0 +1,123 @@
+import json
+import bpy
+import inspect
+
+from .form_to_object import get_data_from_active_editor
+
+from .op_insert_component import insert_component_data
+
+from .skein_panel import draw_generic_panel, render_two
+
+from .object_to_form import object_to_form
+from .property_groups import hash_over_64
+
+def get_targets(self, context):
+    match self.ty:
+        case "MESH":
+            return [
+                ("active_material","active_material",""),
+            ]
+        case "LIGHT":
+            return [("idk","idk","")]
+        case "CAMERA":
+            return [("whatever","whatever","")]
+
+        # If an exact match is not confirmed, this last case will be used if provided
+        case _:
+            return [("no options","no options","")]
+
+class SelectedObjectOptions(bpy.types.PropertyGroup):
+    """Options that correspond to selected objects
+    """
+    ty: bpy.props.StringProperty()
+    targets: bpy.props.EnumProperty(
+        name="target",
+        items=get_targets,
+        default=0
+    )
+
+class InsertComponent(bpy.types.Operator):
+    """Insert Components on Selected Objects
+    
+    """
+    bl_idname = 'wm.insert_component_modal'
+    bl_label = 'Insert Components'
+    bl_description ='Select objects and insert components'
+    bl_options = {'REGISTER', 'UNDO'}
+
+    selected: bpy.props.CollectionProperty(
+        type=SelectedObjectOptions,
+    )
+    # active_component_index = bpy.props.IntProperty(
+    #     min=0,
+    #     override={"LIBRARY_OVERRIDABLE"},
+    # )
+    # ty = bpy.props.EnumProperty(
+    #     name="type",
+    #     items=[
+    #         ("object","object","object is available"),
+    #         ("mesh","mesh","mesh is available"),
+    #         ("material","material","material is available")
+    #     ],
+    #     default="mesh"
+    # )
+    # skein_two = bpy.props.PointerProperty()
+    # obj_file = bpy.props.StringProperty()
+
+    def execute(self, context):
+        skein_property_groups = context.window_manager.skein_property_groups
+
+        # Iterate over all targets with a skein_two field, setting up
+        # the component data for each.
+        # "with a skein_two field" is controlled by the bpy.types setups
+        # and the limits inflicted by the operator's enum lists
+        for i, target_object in enumerate(bpy.context.selected_objects):
+            user_selected_target_object = getattr(target_object, self.selected[i].targets)
+            for component in context.window_manager.skein_two:
+                type_path = component["selected_type_path"]
+                ## create the new component, touching all PointerProperty fields
+                ## with a "forced" type_path.
+                insert_component_data(context, user_selected_target_object, type_path)
+
+                target_skein_two = user_selected_target_object.skein_two
+                # -1 is "last element in list"
+                component_container = target_skein_two[-1]
+                ## Get data from user-created component
+                if inspect.isclass(skein_property_groups[type_path]):
+                    data = get_data_from_active_editor(component, hash_over_64(type_path))
+                    object_to_form(
+                        component_container,
+                        hash_over_64(type_path),
+                        data
+                    )
+                else:
+                    data = getattr(component, hash_over_64(type_path))
+                    setattr(component_container, hash_over_64(type_path), data)
+
+        self.selected.clear()
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        # self.data = {}
+        # return self.execute(context)
+        wm = context.window_manager
+        ## clear any old skein_two data
+        wm.skein_two.clear()
+        for id in context.selected_ids:
+            print("adding", id.type)
+            select = self.selected.add()
+            select.ty = id.type
+        return wm.invoke_props_dialog(self, confirm_text="Insert Components")
+
+    def draw(self, context):
+        split = self.layout.row()
+        col = split.column()
+        for selected in self.selected:
+            layout = col.column()
+            layout.label(text=selected.ty)
+            layout.prop(selected, "targets")
+        # draw_generic_panel(context, obj, self.layout, "object", "OBJECT_PT_skein_preset_panel")
+        draw_generic_panel(context, context.window_manager, split.column(), "wm", "OBJECT_PT_skein_preset_panel")
+
+
+

--- a/extension/op_remove_component.py
+++ b/extension/op_remove_component.py
@@ -97,6 +97,20 @@ class RemoveComponentOnBone(bpy.types.Operator):
     def execute(self, context):
         remove_component_data(context, context.bone)
         return {'FINISHED'}
+
+class RemoveComponentOnWindowManager(bpy.types.Operator):
+    """Remove a component"""
+    bl_idname = "wm.remove_component" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Remove Component" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    # @classmethod
+    # def poll(cls, context):
+    #     return context.bone is not None
+
+    def execute(self, context):
+        remove_component_data(context, context.window_manager)
+        return {'FINISHED'}
     
 ###
 def remove_component_data(context, obj):


### PR DESCRIPTION
An initial implementation of "select many objects, insert components"

The workflow as implemented requires that all components are going to accept the same component data. Any further modification can be done as usual in the side panels.

The operator for inserting components can be bound to a key combination, allowing:

1. select objects
2. pick a target for each object (object, mesh, material, etc)
3. create some component data
4. insert data on all specified targets

Here's the current example showing inserting onto the active material for 3 meshes

<img width="2052" height="1682" alt="screenshot-2025-09-25-at-02 02 48@2x" src="https://github.com/user-attachments/assets/a57bea64-c282-44ef-90be-05dea3f0cd29" />

<img width="2458" height="1298" alt="screenshot-2025-09-25-at-02 03 21@2x" src="https://github.com/user-attachments/assets/b5059d61-53bd-4ec0-935e-ea29a26d4dce" />


TODO:

- Preset application in the popup
- identify all blender ID types and their associated targets
	- this includes the constraints for when those targets are active; ex: an "active_material" target only exists if there is a material on the object, which doesn't happen by default when shift-A inserting a mesh.
- Maybe some layout changes. Trying to keep the same "look/ux" for the panels and the popup overall
- Documentation
	- how to set up a key combo to trigger this
	- what the ui means