### PR TITLE
update bevy version reference on Quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ opengraph_image: /opengraph/opengraph-quickstart.jpg
 
 Using either the [Bevy CLI](https://github.com/thebevyflock/bevy_cli) or [`cargo-generate`](https://cargo-generate.github.io/cargo-generate/) you can scaffold a new Bevy application with Skein pre-installed and a .gltf file ready to go.
 
-## Bevy 0.16 (stable)
+## Bevy 0.17 (stable)
 
 Using the [Bevy CLI](https://github.com/thebevyflock/bevy_cli) (currently under development):
 


### PR DESCRIPTION
I would normally put a description but like... 
Closes #73 