### PR TITLE
add a button to fetch type registry from Skein Bevy Panel

### DIFF
--- a/extension/skein_panel.py
+++ b/extension/skein_panel.py
@@ -152,6 +152,9 @@ def draw_generic_panel(context, obj, layout, execute_mode, skein_preset_panel_id
         row = layout.row()
 
         if registry:
+            row = layout.row(align=True)
+            row.operator("wm.fetch_type_registry", text="Fetch a Remote Type Registry")
+
             layout.label(text="Insert a new Component")
             box = layout.box()
             box.prop_search(


### PR DESCRIPTION
The Skein Bevy Panel gets a new button if the registry is already populated to refetch data. 

<img width="321" height="304" alt="image" src="https://github.com/user-attachments/assets/a6561ab3-8f92-43f4-bafd-538a412cf696" />


Closes #72 