### PR TITLE
Lightmap Baking

### DIFF
--- a/extension/op_bake_lightmaps.py
+++ b/extension/op_bake_lightmaps.py
@@ -1,0 +1,67 @@
+import bpy
+
+class BakeAllLightmaps(bpy.types.Operator):
+    """Bake all configured Lightmaps"""
+    bl_idname = "wm.bake_lightmaps" # unique identifier. first word needs to be from a specific list to appear in keybinds, etc.
+    bl_label = "Bake All Lightmaps" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    # not sure what the right "poll" is for a global method like this
+    # @classmethod
+    # def poll(cls, context):
+    #     return context.object is not None
+
+    def execute(self, context):
+        # Bake for all meshes, no filter yet
+        # Future: bake for meshes with "lightmap" checked
+        for object in bpy.data.objects:
+            if object.type != "MESH":
+                print("skipping", object.type, " named ", object.name)
+                # If this isn't a MESH, we can't continue
+                continue
+            else:
+                print("baking", object.name)
+
+            # We use the filename multiple times, so
+            # store it for re-use
+            filename = f"{object.name}.lightmap.png"
+
+            # get or create the image target for the bake
+            image = bpy.data.images.get(filename)
+            if not image:
+                print("making new image for ", filename)
+                image = bpy.data.images.new(
+                    filename,
+                    width=1024,
+                    height=1024,
+                    alpha=False
+                )
+            # set the image target as a node in the node_tree
+            # and make sure it is "active" for the bake
+            node_tree = object.active_material.node_tree
+            image_node = node_tree.nodes.get(image.name)
+            if not image_node:
+                print("making new image_node for ", filename)
+                image_node = node_tree.nodes.new("ShaderNodeTexImage")
+                image_node.name = image.name
+            image_node.image = image
+            image_node.select = True
+            node_tree.nodes.active = image_node
+            
+            # set current object to be "selected" by overriding
+            # "the context" just for the operator
+            context_override = bpy.context.copy()
+            context_override["selected_objects"] = [object]
+
+            with bpy.context.temp_override(**context_override):
+                # bake image
+                bpy.ops.object.bake(
+                    type="COMBINED",
+                    pass_filter={"DIRECT", "INDIRECT", "DIFFUSE"},
+                    save_mode="EXTERNAL",
+                    filepath=filename,
+                    width=1024,
+                    height=1024,
+                )
+        return {'FINISHED'}
+


### PR DESCRIPTION
Bevy supports Lightmaps! But nobody uses them because most people don't know how. Blender can bake lightmap images, and Skein can help get those images into Bevy as Lightmap components. Hopefully this increases the amount of people using lightmaps (because they make static things look great!)

---

So far Lightmap generation works, but images are stored in the relevant material which seems a bit awkward and could lead to garbage build-up if objects are renamed->baked->renamed.

Other bake tools don't necessarily create materials, although some have the option to create "lightmap materials" on by default. This would provide a place to handle images per-bake at the cost of materials that are probably going to go unused.

<img width="3840" height="2160" alt="screenshot-2025-10-28-at-10 24 31@2x" src="https://github.com/user-attachments/assets/cd87dd34-b1b1-475c-8558-ea018633950e" />

<img width="3392" height="2106" alt="screenshot-2025-11-05-at-16 15 53@2x" src="https://github.com/user-attachments/assets/66c53bc4-749e-43ea-94e1-2a217fcfbed2" />

## TODO:

- [ ] Figure out where to store lightmap images in Blender
- [ ] Figure out if storing generated images in the blendfile is desired, or if they should be required to be generated on-demand before exporting (blend file size vs time-to-bake tradeoff)
- [ ] Enable export of lightmaps
	- [ ] standalone, for users who make use of trenchbroom or other editors
		- these users can import their scenes to blender, click bake, get images to use on the filesystem (and maybe the metadata file for the mapping)
	- [ ] in glTF data.
		- Ideally this is some combination of Skein Components (`Lightmap`) and glTF extension that references images in the glTF export.
- [ ] Instantiation of the relevant lightmap data as `Lightmap` components in Bevy scene when spawned.
