### PR TITLE
change component path works

### DIFF
--- a/extension/__init__.py
+++ b/extension/__init__.py
@@ -3,6 +3,7 @@ import json
 from bpy.app.handlers import persistent
 from .op_apply_preset import ApplyPresetToBone, ApplyPresetToCollection, ApplyPresetToLight, ApplyPresetToMaterial, ApplyPresetToMesh, ApplyPresetToObject, ApplyPresetToScene
 from .cli_dump_component_data import dump_component_data # type: ignore
+from .cli_change_component_path import change_component_path # type: ignore
 from .op_insert_component import InsertComponentOnBone, InsertComponentOnCollection, InsertComponentOnLight, InsertComponentOnMaterial, InsertComponentOnMesh, InsertComponentOnObject, InsertComponentOnScene
 from .op_registry_loading import FetchRemoteTypeRegistry, ReloadSkeinRegistryJson
 from .op_remove_component import RemoveComponentOnBone, RemoveComponentOnCollection, RemoveComponentOnLight, RemoveComponentOnMaterial, RemoveComponentOnMesh, RemoveComponentOnObject, RemoveComponentOnScene
@@ -215,6 +216,7 @@ def register():
     bpy.app.handlers.load_post.append(on_post_blend_file_load)
 
     cli_commands.append(bpy.utils.register_cli_command("dump_component_data", dump_component_data))
+    cli_commands.append(bpy.utils.register_cli_command("change_component_path", change_component_path))
 
     # Use the following 2 lines to register the UI for the gltf extension hook
     from io_scene_gltf2 import exporter_extension_layout_draw # type: ignore


### PR DESCRIPTION
This PR implements a new CLI command that can change the type_path of a component in a blendfile.


The command requires the old and new path, which must match the intended old/new component paths respectively.

```
blender --background -b art/tunic.blend -c change_component_path --old_path tunic_bush::BushSensor --new_path api::BushSensor
```

The output shows the names of objects that were modified.

```json
{
  "object": [
    "ActivationSensor"
  ],
  "mesh": [],
  "material": [],
  "scene": [],
  "collection": []
}
```

Here's a component I successfully updated and changed the name of from the CLI:

<img width="1250" height="588" alt="screenshot-2025-11-11-at-21 32 49@2x" src="https://github.com/user-attachments/assets/5ae1cae9-881a-4331-aeb9-2cf3bd38483e" />


## Caveats

I have only tested this on a blendfile that:

- *did not* have the old component in its registry
- *did* have the new component in the registry
- was a marker component (so the "data" was an empty object)