### PR TITLE
Fix some identifiers using names taken from an example

### DIFF
--- a/extension/__init__.py
+++ b/extension/__init__.py
@@ -195,7 +195,7 @@ def register():
 
     # Use the following 2 lines to register the UI for the gltf extension hook
     from io_scene_gltf2 import exporter_extension_layout_draw # type: ignore
-    exporter_extension_layout_draw['Example glTF Extension'] = draw_export # Make sure to use the same name in unregister()
+    exporter_extension_layout_draw['Skein'] = draw_export # Make sure to use the same name in unregister()
 
 def unregister():
     global_skein = bpy.context.window_manager.skein
@@ -255,4 +255,4 @@ def unregister():
 
     # Use the following 2 lines to unregister the UI for this hook
     from io_scene_gltf2 import exporter_extension_layout_draw # type: ignore
-    del exporter_extension_layout_draw['Example glTF Extension'] # Make sure to use the same name in register()
+    del exporter_extension_layout_draw['Skein'] # Make sure to use the same name in register()

--- a/extension/gltf_export_extension.py
+++ b/extension/gltf_export_extension.py
@@ -60,7 +60,7 @@ def draw_export(context, layout):
     # if context.collection.name != "Coll":
     #     return
 
-    header, body = layout.panel("GLTF_addon_example_exporter", default_closed=False)
+    header, body = layout.panel("GLTF_addon_skein_exporter", default_closed=False)
 
     # TODO: True or False here (and in panels)? Affects visual layout
     header.use_property_split = False


### PR DESCRIPTION
I was wondering why my own addon was making Skein disappear, then I found out we both forgot to change these names :D so there was a clash there, which lead to my addon overriding yours.