### PR TITLE
Fix exception when body is `None`

### DIFF
--- a/extension/gltf_export_extension.py
+++ b/extension/gltf_export_extension.py
@@ -68,8 +68,9 @@ def draw_export(context, layout):
     props = bpy.context.scene.skein_extension_properties
 
     header.prop(props, 'enabled')
-    body.prop(props, 'extras')
-    body.prop(props, 'extensions')
+    if body != None:
+        body.prop(props, 'extras')
+        body.prop(props, 'extensions')
 
     # if body != None:
     #     body.prop(props, 'float_property', text="Some float value")


### PR DESCRIPTION
While developing an own plugin that also uses the glTF exporter, I wanted to minimize the Skein panel to reduce visual clutter. Well, that tripped a `NoneType` error on `body`. I don't know why `body` would be `None` in some contexts, but my personal hypothesis is that collapsing the section makes the body disappear and thus be `None`.
Given that the upstream example also does `if body != None:`, this state of affairs seems at least like a known phenomenon? 