### PR TITLE
Fix text alignment

### DIFF
--- a/extension/gltf_export_extension.py
+++ b/extension/gltf_export_extension.py
@@ -67,7 +67,8 @@ def draw_export(context, layout):
 
     props = bpy.context.scene.skein_extension_properties
 
-    header.prop(props, 'enabled')
+    header.prop(props, 'enabled', text="")
+    header.label(text="Skein")
     body.prop(props, 'extras')
     body.prop(props, 'extensions')
 


### PR DESCRIPTION
I noticed that Skein was aligned differently in its options than the builtin stuff like `Animation`:
<img width="163" height="53" alt="image" src="https://github.com/user-attachments/assets/c6665f63-9339-482c-8fbe-1fe29a4e4274" />
So I checked how the glTF exporter does it upstream: https://github.com/KhronosGroup/glTF-Blender-IO/blob/bf5e1fdabf9370abc6133d7e74ebb39bc52cac96/addons/io_scene_gltf2/__init__.py#L1753-L1754
and ported that to Skein:
<img width="140" height="54" alt="image" src="https://github.com/user-attachments/assets/a8b01d6e-1928-486e-a1b7-df08c88a8de2" />
