### PR TITLE
Extension system to override component UI and serialization

### DIFF
--- a/extension/op_registry_loading.py
+++ b/extension/op_registry_loading.py
@@ -153,6 +153,38 @@ class ReloadSkeinRegistryJson(bpy.types.Operator):
 
         return {'FINISHED'}
 
+
+def __compute_make_property_settings():
+    """
+    Compute settings for make_property:
+    - gather extensions from loaded addons
+
+    :return: the settings for make_property
+    """
+    import sys
+
+    debug = False
+    if __package__ in bpy.context.preferences.addons:
+        debug = bpy.context.preferences.addons[__package__].preferences.debug
+
+    settings = {}
+
+    extensions = []
+    preferences = bpy.context.preferences
+    for addon_name in preferences.addons.keys():
+        try:
+            module = sys.modules[addon_name]
+        except Exception:
+            continue
+        if hasattr(module, 'skein_make_property_extension'):
+            extensions.append(module.skein_make_property_extension)
+            if debug:
+                print(f'Found skein_make_property_extension in {addon_name}')
+    settings['extensions'] = extensions
+
+    return settings
+
+
 def process_registry(context, registry):
     """
     registry is a dict
@@ -200,6 +232,8 @@ def process_registry(context, registry):
     # Clear the list that held the PropertyGroups because we are about
     # to re-fill it.
     skein_property_groups.clear()
+
+    make_property_settings = __compute_make_property_settings()
 
     # for each user-defined type, make a PropertyGroup that represents
     # that type. These will be used to build out user-accessible forms

--- a/extension/property_groups.py
+++ b/extension/property_groups.py
@@ -78,6 +78,14 @@ def make_property(
     if "kind" not in component:
         if debug:
             print("kind not in ", type_path, component)
+
+    if "extensions" in make_property_settings:
+        # Run extension first in case they override this component
+        for extension in make_property_settings["extensions"]:
+            ext = extension(skein_property_groups, component, type_path, make_property_settings)
+            if ext is not None:
+                return ext
+
     match component["kind"]:
         # Array is fixed-size arrays
         case "Array":
@@ -221,7 +229,8 @@ def make_property(
                     property = make_property(
                         skein_property_groups,
                         registry,
-                        component["properties"][key]["type"]["$ref"]
+                        component["properties"][key]["type"]["$ref"],
+                        make_property_settings,
                     )
                     if inspect.isclass(property):
                         annotations[key] = bpy.props.PointerProperty(
@@ -254,7 +263,8 @@ def make_property(
                 skein_property_groups[type_path] = make_property(
                     skein_property_groups,
                     registry,
-                    component["prefixItems"][0]["type"]["$ref"]
+                    component["prefixItems"][0]["type"]["$ref"],
+                    make_property_settings,
                 )
                 return skein_property_groups[type_path]
             else:

--- a/extension/property_groups_test.py
+++ b/extension/property_groups_test.py
@@ -39,7 +39,8 @@ class TestClass:
             bpy.types.Scene.test_data = make_property(
                 skein_property_groups,
                 registry,
-                'test_components::Marker'
+                'test_components::Marker',
+                {}
             )
             assert "test_components::Marker" in skein_property_groups
 
@@ -56,7 +57,8 @@ def check_fields(type_path, fields):
         bpy.types.Scene.active_editor = make_property(
             skein_property_groups,
             registry,
-            type_path
+            type_path,
+            {}
         )
 
         assert type_path in skein_property_groups


### PR DESCRIPTION
Using the same design used for `glTF2ExportUserExtension`, users can now create a blender extension that defines overrides for the `make_property` function.

The main module must contains a function with this signature: `skein_make_property_extension(skein_property_groups, component, type_path, settings)`
it should return:
- A property (from `bpy.props`)
- A `ComponentData` (class defined in `bevy_skein.property_groups` with annotations
- None if not handled, in that case, the default behavior is expected

# Use case
When the serialization format differs from the reflected data, the exported Gltf must have the serialization format.
By using this extension mechanism, a user can override how a component is handled, ignoring its reflection data.

## Example
Interned string uses integers ids, but represents a string. The interned id may change between runs, thus using the string is both stable and human friendly.

On the bevy side, using `bevy_reflect::serde::SerializeWithRegistry` and `bevy_reflect::serde::DeserializeWithRegistry` can override this behavior for serialization:
```rust

impl<T, const N: usize> SerializeWithRegistry for GameplayTag<T, N> {
    fn serialize<S>(&self, serializer: S, _registry: &TypeRegistry) -> Result<S::Ok, S::Error>
    where
        S: ::serde::ser::Serializer,
    {
        serializer.serialize_str(&self)
    }
}

impl<'de, T, const N: usize> DeserializeWithRegistry<'de> for GameplayTag<T, N>
where
    T: GameplayTagStorage,
    <T as TryFrom<usize>>::Error: Debug,
{
    fn deserialize<D>(deserializer: D, registry: &TypeRegistry) -> Result<Self, D::Error>
    where
        D: de::Deserializer<'de>,
    {
        let registry = registry
            .get_type_data::<GameplayTagRegistry<T, N>>(TypeId::of::<GameplayTag<T, N>>())
            .expect(
                "GameplayTagRegistry must be registered as TypeData of GameplayTag.\
                 Did you added the GameplayTagPlugin and wait for App::finish?",
            );

        return deserializer.deserialize_str(GameplayTagVisitor { registry });

        struct GameplayTagVisitor<'a, T, const N: usize> {
            registry: &'a GameplayTagRegistry<T, N>,
        }

        impl<'a, 'de, T, const N: usize> de::Visitor<'de> for GameplayTagVisitor<'a, T, N>
        where
            T: GameplayTagStorage,
            <T as TryFrom<usize>>::Error: Debug,
        {
            type Value = GameplayTag<T, N>;

            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                write!(
                    formatter,
                    "Expected a string with format (regexp): \\d+(\\.\\d+)*, ex: this.is.my.tag"
                )
            }

            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
            where
                E: de::Error,
            {
                self.registry.get(s).ok_or_else(|| {
                    de::Error::custom(format!(
                        "Unknown gameplay tag: {s}, please register it in plugins."
                    ))
                })
            }
        }
    }
}
```

and on the blender side, adding a new [add-on](https://developer.blender.org/docs/handbook/extensions/addon_dev_setup/) with:
```python
def skein_make_property_extension(
        skein_property_groups,
        component,
        type_path,
        settings,
):
    match type_path:
        case "bevy_gameplay_tags::gameplay_tag::GameplayTag<u8, 8>":
            return bpy.props.StringProperty(
                override={"LIBRARY_OVERRIDABLE"},
            )
        case "feat_prototype::player_spawn::PlayerSpawn":
            # PlayerSpawn {
            #     tag: GameplayTag<u8, 8>,
            # }
            annotations = {"tag": bpy.props.StringProperty(
                override={"LIBRARY_OVERRIDABLE"},
            )}

            # add this struct type to the skein_property_groups so it
            # can be accessed elsewhere by type_path
            t = capitalize_path(type_path)
            skein_property_groups[type_path] = type(t, (ComponentData,), {
                '__annotations__': annotations,
            })

            # registering the class is required for certain Blender
            # functionality to work.
            bpy.utils.register_class(
                skein_property_groups[type_path]
            )

            # return the type we just constructed
            return skein_property_groups[type_path]
    return None
```

