### PR TITLE
Implement rough list & touple support

### DIFF
--- a/extension/__init__.py
+++ b/extension/__init__.py
@@ -5,10 +5,12 @@ from .op_apply_preset import register as register_op_apply_preset, unregister as
 from .cli_dump_component_data import dump_component_data # type: ignore
 from .cli_change_component_path import change_component_path # type: ignore
 from .op_insert_component import register as register_op_insert_component, unregister as unregister_op_insert_component
+from .op_append_component_list_entry import register as register_op_append_component_list_entry, unregister as unregister_op_append_component_list_entry
 from .op_registry_loading import FetchRemoteTypeRegistry, ReloadSkeinRegistryJson
 from .op_remove_component import register as register_op_remove_component, unregister as unregister_op_remove_component
+from .op_remove_component_list_entry import register as register_op_remove_component_list_entry, unregister as unregister_op_remove_component_list_entry
 from .op_debug_check_components import DebugCheckComponents
-from .property_groups import ComponentData
+from .property_groups import ComponentData, PathKeyGroup
 from .skein_panel import register as register_skein_panel, unregister as unregister_skein_panel
 from .skein_panel_presets import register as register_skein_panel_presets, unregister as unregister_skein_panel_presets
 from .skein_sidepanel import register as register_skein_sidepanel, unregister as unregister_skein_sidepanel
@@ -115,6 +117,7 @@ def register():
     # for quick access.
     bpy.utils.register_class(ComponentTypeData)
     bpy.utils.register_class(ComponentData)
+    bpy.utils.register_class(PathKeyGroup)
     bpy.utils.register_class(PGSkeinWindowProps)
     bpy.types.WindowManager.skein = bpy.props.PointerProperty(type=PGSkeinWindowProps)
 
@@ -169,8 +172,10 @@ def register():
     bpy.utils.register_class(DebugCheckComponents)
     ## Insertion Operations
     register_op_insert_component()
+    register_op_append_component_list_entry()
     ## Remove Operations
     register_op_remove_component()
+    register_op_remove_component_list_entry()
     ## Export Operations
     register_op_trigger_collection_exporters()
     ## Preset Operations
@@ -231,8 +236,10 @@ def unregister():
     bpy.utils.unregister_class(DebugCheckComponents)
     ## Insertion Operations
     unregister_op_insert_component()
+    unregister_op_append_component_list_entry()
     ## Remove Operations
     unregister_op_remove_component()
+    unregister_op_remove_component_list_entry()
     ## Export Operations
     unregister_op_trigger_collection_exporters()
     ## Preset Operations

--- a/extension/form_to_object.py
+++ b/extension/form_to_object.py
@@ -28,7 +28,7 @@ def get_data_from_active_editor(context, context_key, index = None):
                     if "PointerProperty" == annotations["Some"].function.__name__:
                         return get_data_from_active_editor(obj, "Some")
                     else:
-                        return getattr(obj, "Some")
+                        return getattr(obj, "Some").inner
     except AttributeError:
         # Not all PropertyGroups have the is_core_option attribute, so
         # this is a common failure case that doesn't actually mean failure
@@ -77,7 +77,7 @@ def get_data_from_active_editor(context, context_key, index = None):
                     }
                 else:
                     return { 
-                        value: getattr(obj, value)
+                        value: getattr(obj, value).inner
                     }
 
     # attempt to handle any type overrides, like glam::Vec3
@@ -224,6 +224,12 @@ def get_data_from_active_editor(context, context_key, index = None):
                     return []
     except AttributeError:
         pass
+    
+    try:
+        if obj.is_value:
+            return obj.inner
+    except AttributeError:
+        pass
 
     # No more special handling, just take the keys and values that are
     # in the annotations, and plug them into the object
@@ -239,9 +245,11 @@ def get_data_from_active_editor(context, context_key, index = None):
                     continue
             except AttributeError as e:
                 pass
-            print(obj)
             data[key] = get_data_from_active_editor(obj, key)
         else:
-            print(obj)
-            data[key] = getattr(obj, key)
+            try:
+                if getattr(obj, key).is_value:
+                    data[key] = getattr(obj, key).inner
+            except:
+                data[key] = getattr(obj, key)
     return data

--- a/extension/form_to_object.py
+++ b/extension/form_to_object.py
@@ -233,13 +233,15 @@ def get_data_from_active_editor(context, context_key, index = None):
             try:
                 if getattr(obj, key).is_value:
                     try:
-                        data[key] = get_data_from_active_editor(value, "inner")
-                    except:
+                        data[key] = getattr(obj, key).inner
+                    except Exception as e:
                         pass
                     continue
             except AttributeError as e:
                 pass
+            print(obj)
             data[key] = get_data_from_active_editor(obj, key)
         else:
+            print(obj)
             data[key] = getattr(obj, key)
     return data

--- a/extension/form_to_object.py
+++ b/extension/form_to_object.py
@@ -90,39 +90,39 @@ def get_data_from_active_editor(context, context_key, index = None):
         match obj.type_override:
             case "glam::Vec2" | "glam::DVec2" | "glam::I8Vec2" | "glam::U8Vec2" | "glam::I16Vec2" | "glam::U16Vec2" | "glam::IVec2" | "glam::UVec2" | "glam::I64Vec2" | "glam::U64Vec2" | "glam::BVec2":
                 return [
-                    getattr(obj, "x"),
-                    getattr(obj, "y"),
+                    getattr(obj.x, "inner"),
+                    getattr(obj.y, "inner"),
                 ]
             case "glam::Vec3" | "glam::Vec3A" | "glam::DVec3" | "glam::I8Vec3" | "glam::U8Vec3" | "glam::I16Vec3" | "glam::U16Vec3" | "glam::IVec3" | "glam::UVec3" | "glam::I64Vec3" | "glam::U64Vec3" | "glam::BVec3":
                 return [
-                    getattr(obj, "x"),
-                    getattr(obj, "y"),
-                    getattr(obj, "z"),   
+                    getattr(obj.x, "inner"),
+                    getattr(obj.y, "inner"),
+                    getattr(obj.z, "inner"),   
                 ]
             case "glam::Vec4" | "glam::DVec4" | "glam::I8Vec4" | "glam::U8Vec4" | "glam::I16Vec4" | "glam::U16Vec4" | "glam::IVec4" | "glam::UVec4" | "glam::I64Vec4" | "glam::U64Vec4" | "glam::BVec4":
                 return [
-                    getattr(obj, "x"),
-                    getattr(obj, "y"),
-                    getattr(obj, "z"),
-                    getattr(obj, "w"),
+                    getattr(obj.x, "inner"),
+                    getattr(obj.y, "inner"),
+                    getattr(obj.z, "inner"),
+                    getattr(obj.w, "inner"),
                 ]
             case "glam::Quat" | "glam::DQuat":
                 return [
-                    getattr(obj, "x"),
-                    getattr(obj, "y"),
-                    getattr(obj, "z"),
-                    getattr(obj, "w"),
+                    getattr(obj.x, "inner"),
+                    getattr(obj.y, "inner"),
+                    getattr(obj.z, "inner"),
+                    getattr(obj.w, "inner"),
                 ]
             case "glam::Mat2" | "glam::DMat2":
                 x_axis = getattr(obj, "x_axis")
                 y_axis = getattr(obj, "y_axis")
                 
                 return [
-                    getattr(x_axis, "x"),
-                    getattr(x_axis, "y"),
+                    getattr(x_axis.x, "inner"),
+                    getattr(x_axis.y, "inner"),
 
-                    getattr(y_axis, "x"),
-                    getattr(y_axis, "y"),
+                    getattr(y_axis.x, "inner"),
+                    getattr(y_axis.y, "inner"),
                 ]
 
             case "glam::Mat3" | "glam::Mat3A" | "glam::DMat3":
@@ -131,17 +131,17 @@ def get_data_from_active_editor(context, context_key, index = None):
                 z_axis = getattr(obj, "z_axis")
                 
                 return [
-                    getattr(x_axis, "x"),
-                    getattr(x_axis, "y"),
-                    getattr(x_axis, "z"),
+                    getattr(x_axis.x, "inner"),
+                    getattr(x_axis.y, "inner"),
+                    getattr(x_axis.z, "inner"),
 
-                    getattr(y_axis, "x"),
-                    getattr(y_axis, "y"),
-                    getattr(y_axis, "z"),
+                    getattr(y_axis.x, "inner"),
+                    getattr(y_axis.y, "inner"),
+                    getattr(y_axis.z, "inner"),
 
-                    getattr(z_axis, "x"),
-                    getattr(z_axis, "y"),
-                    getattr(z_axis, "z"),
+                    getattr(z_axis.x, "inner"),
+                    getattr(z_axis.y, "inner"),
+                    getattr(z_axis.z, "inner"),
                 ]
             case "glam::Mat4" | "glam::DMat4":
                 x_axis = getattr(obj, "x_axis")
@@ -150,25 +150,25 @@ def get_data_from_active_editor(context, context_key, index = None):
                 w_axis = getattr(obj, "w_axis")
                 
                 return [
-                    getattr(x_axis, "x"),
-                    getattr(x_axis, "y"),
-                    getattr(x_axis, "z"),
-                    getattr(x_axis, "w"),
+                    getattr(x_axis.x, "inner"),
+                    getattr(x_axis.y, "inner"),
+                    getattr(x_axis.z, "inner"),
+                    getattr(x_axis.w, "inner"),
 
-                    getattr(y_axis, "x"),
-                    getattr(y_axis, "y"),
-                    getattr(y_axis, "z"),
-                    getattr(y_axis, "w"),
+                    getattr(y_axis.x, "inner"),
+                    getattr(y_axis.y, "inner"),
+                    getattr(y_axis.z, "inner"),
+                    getattr(y_axis.w, "inner"),
 
-                    getattr(z_axis, "x"),
-                    getattr(z_axis, "y"),
-                    getattr(z_axis, "z"),
-                    getattr(z_axis, "w"),
+                    getattr(z_axis.x, "inner"),
+                    getattr(z_axis.y, "inner"),
+                    getattr(z_axis.z, "inner"),
+                    getattr(z_axis.w, "inner"),
 
-                    getattr(w_axis, "x"),
-                    getattr(w_axis, "y"),
-                    getattr(w_axis, "z"),
-                    getattr(w_axis, "w"),
+                    getattr(w_axis.x, "inner"),
+                    getattr(w_axis.y, "inner"),
+                    getattr(w_axis.z, "inner"),
+                    getattr(w_axis.w, "inner"),
                 ]
   
             case "glam::Affine2" | "glam::DAffine2":
@@ -178,12 +178,12 @@ def get_data_from_active_editor(context, context_key, index = None):
                 translation = getattr(obj, "translation")
                 
                 return [
-                    getattr(x_axis, "x"),
-                    getattr(x_axis, "y"),
-                    getattr(y_axis, "x"),
-                    getattr(y_axis, "y"),
-                    getattr(translation, "x"),
-                    getattr(translation, "y"),
+                    getattr(x_axis.x, "inner"),
+                    getattr(x_axis.y, "inner"),
+                    getattr(y_axis.x, "inner"),
+                    getattr(y_axis.y, "inner"),
+                    getattr(translation.x, "inner"),
+                    getattr(translation.y, "inner"),
                 ]
             case "glam::Affine3A" | "glam::DAffine3":
                 mat = getattr(obj, "matrix3")
@@ -193,18 +193,18 @@ def get_data_from_active_editor(context, context_key, index = None):
                 translation = getattr(obj, "translation")
                 
                 return [
-                    getattr(x_axis, "x"),
-                    getattr(x_axis, "y"),
-                    getattr(x_axis, "z"),
-                    getattr(y_axis, "x"),
-                    getattr(y_axis, "y"),
-                    getattr(y_axis, "z"),
-                    getattr(z_axis, "x"),
-                    getattr(z_axis, "y"),
-                    getattr(z_axis, "z"),
-                    getattr(translation, "x"),
-                    getattr(translation, "y"),
-                    getattr(translation, "z"),
+                    getattr(x_axis.x, "inner"),
+                    getattr(x_axis.y, "inner"),
+                    getattr(x_axis.z, "inner"),
+                    getattr(y_axis.x, "inner"),
+                    getattr(y_axis.y, "inner"),
+                    getattr(y_axis.z, "inner"),
+                    getattr(z_axis.x, "inner"),
+                    getattr(z_axis.y, "inner"),
+                    getattr(z_axis.z, "inner"),
+                    getattr(translation.x, "inner"),
+                    getattr(translation.y, "inner"),
+                    getattr(translation.z, "inner"),
                 ]
             
     except AttributeError:
@@ -230,6 +230,15 @@ def get_data_from_active_editor(context, context_key, index = None):
     data = {}
     for key, value in annotations.items():
         if "PointerProperty" == value.function.__name__:
+            try:
+                if getattr(obj, key).is_value:
+                    try:
+                        data[key] = get_data_from_active_editor(value, "inner")
+                    except:
+                        pass
+                    continue
+            except AttributeError as e:
+                pass
             data[key] = get_data_from_active_editor(obj, key)
         else:
             data[key] = getattr(obj, key)

--- a/extension/form_to_object.py
+++ b/extension/form_to_object.py
@@ -1,14 +1,17 @@
 # get json data from an active_editor
-def get_data_from_active_editor(context, context_key):
+def get_data_from_active_editor(context, context_key, index = None):
     """get the data from a ComponentContainer
     The initial context is typically the ComponentContainer and the 
     typical context_key is the type_path of the Component
     """
     if context_key not in context:
         return {}
-    
+
     # The current PropertyGroup we're working with
     obj = getattr(context, context_key)
+
+    if index is not None: # traverse into arrays, lists etc. if an index is
+        obj = obj[index]  # provided in addition to the context_key
 
     # get the annotations, which will give us all of the field names
     # and their value types for this PropertyGroup
@@ -29,6 +32,30 @@ def get_data_from_active_editor(context, context_key):
     except AttributeError:
         # Not all PropertyGroups have the is_core_option attribute, so
         # this is a common failure case that doesn't actually mean failure
+        pass
+
+    # Handle tuples by merging their fields into an array 
+    # to match what serde json expects them to look like
+    try:
+        if obj.is_tuple:
+            tuple_length = getattr(obj, 'tuple_length')
+            data = []
+            for i in range(tuple_length): 
+                data.append(get_data_from_active_editor(obj, str(i)))
+            return data
+    except AttributeError:
+        # Same as for obj.is_core_option, not having an is_tuple field is not a hard failure
+        pass
+
+    # Handle lists (and sets) by traversing into the inner 'list_wrapper'
+    # CollectionProperty and gathering all values from it into a list
+    try:
+        if obj.is_list:
+            data = []
+            for i, item in enumerate(getattr(obj, "list_wrapper")):
+                data.append(get_data_from_active_editor(obj, "list_wrapper", i))
+            return data
+    except AttributeError:
         pass
 
     # If we have a `skein_enum_index`, then we have the representation

--- a/extension/object_to_form.py
+++ b/extension/object_to_form.py
@@ -1,6 +1,6 @@
 # put json data into an active_editor
 # This is the inverse of `form_to_object`
-def object_to_form(context, context_key, data):
+def object_to_form(context, context_key, data, index = None):
     """insert data into a ComponentContainer
     context is the ComponentContainer
     context_key is the type_path
@@ -11,6 +11,9 @@ def object_to_form(context, context_key, data):
     
     # The current PropertyGroup we're working with
     obj = getattr(context, context_key)
+
+    if index is not None: # traverse into arrays, lists etc. if an index is
+        obj = obj[index]  # provided in addition to the context_key
 
     # get the annotations, which will give us all of the field names
     # and their value types for this PropertyGroup
@@ -34,6 +37,27 @@ def object_to_form(context, context_key, data):
     except AttributeError:
         # Not all PropertyGroups have the is_core_option attribute, so
         # this is a common failure case that doesn't actually mean failure
+        pass
+
+    # Handle tuples by merging their fields into an array 
+    # to match what serde json expects them to look like
+    try:
+        if obj.is_tuple:
+            for i, item in enumerate(data):
+                object_to_form(obj, str(i), item)
+            return
+    except AttributeError:
+        # Same as for obj.is_core_option, not having an is_tuple field is not a hard failure
+        pass
+
+    # Handle lists (and sets) by traversing into the inner 'list_wrapper'
+    # CollectionProperty and gathering all values from it into a list
+    try:
+        if obj.is_list:
+            for i, item in enumerate(data):
+                object_to_form(obj, "list_wrapper", item, i)
+            return
+    except AttributeError:
         pass
 
     # If we have a `skein_enum_index`, then we have the representation
@@ -68,7 +92,6 @@ def object_to_form(context, context_key, data):
     # properly indicating that a Vec3 has x,y,z fields. BUT the serialization
     # is overridden and actually needs to be an array of 3 values
     try:
-        print("obj.type_override", obj.type_override)
         match obj.type_override:
             case "glam::Vec2" | "glam::DVec2" | "glam::I8Vec2" | "glam::U8Vec2" | "glam::I16Vec2" | "glam::U16Vec2" | "glam::IVec2" | "glam::UVec2" | "glam::I64Vec2" | "glam::U64Vec2" | "glam::BVec2":
                 return [

--- a/extension/object_to_form.py
+++ b/extension/object_to_form.py
@@ -95,39 +95,39 @@ def object_to_form(context, context_key, data, index = None):
         match obj.type_override:
             case "glam::Vec2" | "glam::DVec2" | "glam::I8Vec2" | "glam::U8Vec2" | "glam::I16Vec2" | "glam::U16Vec2" | "glam::IVec2" | "glam::UVec2" | "glam::I64Vec2" | "glam::U64Vec2" | "glam::BVec2":
                 return [
-                    setattr(obj, "x", data[0]),
-                    setattr(obj, "y", data[1]),
+                    setattr(obj.x, "inner", data[0]),
+                    setattr(obj.y, "inner", data[1]),
                 ]
             case "glam::Vec3" | "glam::Vec3A" | "glam::DVec3" | "glam::I8Vec3" | "glam::U8Vec3" | "glam::I16Vec3" | "glam::U16Vec3" | "glam::IVec3" | "glam::UVec3" | "glam::I64Vec3" | "glam::U64Vec3" | "glam::BVec3":
                 return [
-                    setattr(obj, "x", data[0]),
-                    setattr(obj, "y", data[1]),
-                    setattr(obj, "z", data[2]),
+                    setattr(obj.x, "inner", data[0]),
+                    setattr(obj.y, "inner", data[1]),
+                    setattr(obj.z, "inner", data[2]),
                 ]
             case "glam::Vec4" | "glam::DVec4" | "glam::I8Vec4" | "glam::U8Vec4" | "glam::I16Vec4" | "glam::U16Vec4" | "glam::IVec4" | "glam::UVec4" | "glam::I64Vec4" | "glam::U64Vec4" | "glam::BVec4":
                 return [
-                    setattr(obj, "x", data[0]),
-                    setattr(obj, "y", data[1]),
-                    setattr(obj, "z", data[2]),
-                    setattr(obj, "w", data[3]),
+                    setattr(obj.x, "inner", data[0]),
+                    setattr(obj.y, "inner", data[1]),
+                    setattr(obj.z, "inner", data[2]),
+                    setattr(obj.w, "inner", data[3]),
                 ]
             case "glam::Quat" | "glam::DQuat":
                 return [
-                    setattr(obj, "x", data[0]),
-                    setattr(obj, "y", data[1]),
-                    setattr(obj, "z", data[2]),
-                    setattr(obj, "w", data[3]),
+                    setattr(obj.x, "inner", data[0]),
+                    setattr(obj.y, "inner", data[1]),
+                    setattr(obj.z, "inner", data[2]),
+                    setattr(obj.w, "inner", data[3]),
                 ]
             case "glam::Mat2" | "glam::DMat2":
                 x_axis = getattr(obj, "x_axis")
                 y_axis = getattr(obj, "y_axis")
                 
                 return [
-                    setattr(x_axis, "x", data[0]),
-                    setattr(x_axis, "y", data[1]),
+                    setattr(x_axis.x, "inner", data[0]),
+                    setattr(x_axis.y, "inner", data[1]),
 
-                    setattr(y_axis, "x", data[2]),
-                    setattr(y_axis, "y", data[3]),
+                    setattr(y_axis.x, "inner", data[2]),
+                    setattr(y_axis.y, "inner", data[3]),
                 ]
 
             case "glam::Mat3" | "glam::Mat3A" | "glam::DMat3":
@@ -136,17 +136,17 @@ def object_to_form(context, context_key, data, index = None):
                 z_axis = getattr(obj, "z_axis")
                 
                 return [
-                    setattr(x_axis, "x", data[0]),
-                    setattr(x_axis, "y", data[1]),
-                    setattr(x_axis, "z", data[2]),
+                    setattr(x_axis.x, "inner", data[0]),
+                    setattr(x_axis.y, "inner", data[1]),
+                    setattr(x_axis.z, "inner", data[2]),
 
-                    setattr(y_axis, "x", data[3]),
-                    setattr(y_axis, "y", data[4]),
-                    setattr(y_axis, "z", data[5]),
+                    setattr(y_axis.x, "inner", data[3]),
+                    setattr(y_axis.y, "inner", data[4]),
+                    setattr(y_axis.z, "inner", data[5]),
 
-                    setattr(z_axis, "x", data[6]),
-                    setattr(z_axis, "y", data[7]),
-                    setattr(z_axis, "z", data[8]),
+                    setattr(z_axis.x, "inner", data[6]),
+                    setattr(z_axis.y, "inner", data[7]),
+                    setattr(z_axis.z, "inner", data[8]),
                 ]
             case "glam::Mat4" | "glam::DMat4":
                 x_axis = getattr(obj, "x_axis")
@@ -155,25 +155,25 @@ def object_to_form(context, context_key, data, index = None):
                 w_axis = getattr(obj, "w_axis")
                 
                 return [
-                    setattr(x_axis, "x", data[0]),
-                    setattr(x_axis, "y", data[1]),
-                    setattr(x_axis, "z", data[2]),
-                    setattr(x_axis, "w", data[3]),
+                    setattr(x_axis.x, "inner", data[0]),
+                    setattr(x_axis.y, "inner", data[1]),
+                    setattr(x_axis.z, "inner", data[2]),
+                    setattr(x_axis.w, "inner", data[3]),
 
-                    setattr(y_axis, "x", data[4]),
-                    setattr(y_axis, "y", data[5]),
-                    setattr(y_axis, "z", data[6]),
-                    setattr(y_axis, "w", data[7]),
+                    setattr(y_axis.x, "inner", data[4]),
+                    setattr(y_axis.y, "inner", data[5]),
+                    setattr(y_axis.z, "inner", data[6]),
+                    setattr(y_axis.w, "inner", data[7]),
 
-                    setattr(z_axis, "x", data[8]),
-                    setattr(z_axis, "y", data[9]),
-                    setattr(z_axis, "z", data[10]),
-                    setattr(z_axis, "w", data[11]),
+                    setattr(z_axis.x, "inner", data[8]),
+                    setattr(z_axis.y, "inner", data[9]),
+                    setattr(z_axis.z, "inner", data[10]),
+                    setattr(z_axis.w, "inner", data[11]),
 
-                    setattr(w_axis, "x", data[12]),
-                    setattr(w_axis, "y", data[13]),
-                    setattr(w_axis, "z", data[14]),
-                    setattr(w_axis, "w", data[15]),
+                    setattr(w_axis.x, "inner", data[12]),
+                    setattr(w_axis.y, "inner", data[13]),
+                    setattr(w_axis.z, "inner", data[14]),
+                    setattr(w_axis.w, "inner", data[15]),
                 ]
   
             case "glam::Affine2" | "glam::DAffine2":
@@ -183,12 +183,12 @@ def object_to_form(context, context_key, data, index = None):
                 translation = getattr(obj, "translation")
                 
                 return [
-                    setattr(x_axis, "x", data[0]),
-                    setattr(x_axis, "y", data[1]),
-                    setattr(y_axis, "x", data[2]),
-                    setattr(y_axis, "y", data[3]),
-                    setattr(translation, "x", data[4]),
-                    setattr(translation, "y", data[5]),
+                    setattr(x_axis.x, "inner", data[0]),
+                    setattr(x_axis.y, "inner", data[1]),
+                    setattr(y_axis.x, "inner", data[2]),
+                    setattr(y_axis.y, "inner", data[3]),
+                    setattr(translation.x, "inner", data[4]),
+                    setattr(translation.y, "inner", data[5]),
                 ]
             case "glam::Affine3A" | "glam::DAffine3":
                 mat = getattr(obj, "matrix3")
@@ -198,18 +198,18 @@ def object_to_form(context, context_key, data, index = None):
                 translation = getattr(obj, "translation")
                 
                 return [
-                    setattr(x_axis, "x", data[0]),
-                    setattr(x_axis, "y", data[1]),
-                    setattr(x_axis, "z", data[2]),
-                    setattr(y_axis, "x", data[3]),
-                    setattr(y_axis, "y", data[4]),
-                    setattr(y_axis, "z", data[5]),
-                    setattr(z_axis, "x", data[6]),
-                    setattr(z_axis, "y", data[7]),
-                    setattr(z_axis, "z", data[8]),
-                    setattr(translation, "x", data[9]),
-                    setattr(translation, "y", data[10]),
-                    setattr(translation, "z", data[11]),
+                    setattr(x_axis.x, "inner", data[0]),
+                    setattr(x_axis.y, "inner", data[1]),
+                    setattr(x_axis.z, "inner", data[2]),
+                    setattr(y_axis.x, "inner", data[3]),
+                    setattr(y_axis.y, "inner", data[4]),
+                    setattr(y_axis.z, "inner", data[5]),
+                    setattr(z_axis.x, "inner", data[6]),
+                    setattr(z_axis.y, "inner", data[7]),
+                    setattr(z_axis.z, "inner", data[8]),
+                    setattr(translation.x, "inner", data[9]),
+                    setattr(translation.y, "inner", data[10]),
+                    setattr(translation.z, "inner", data[11]),
                 ]
             
     except AttributeError:
@@ -225,5 +225,5 @@ def object_to_form(context, context_key, data, index = None):
         if isinstance(data[key], list) or isinstance(data[key], dict) or value.function.__name__ == "PointerProperty":
             object_to_form(getattr(context, context_key), key, data[key])
         else:
-            setattr(obj, key, data[key])
+            setattr(getattr(obj, key), "inner", data[key])
     return

--- a/extension/op_append_component_list_entry.py
+++ b/extension/op_append_component_list_entry.py
@@ -1,0 +1,148 @@
+import bpy
+from .property_groups import hash_over_64, PathKeyGroup
+
+
+class AppendComponentListEntryOnObject(bpy.types.Operator):
+    """Append a component on the selected object"""
+    bl_idname = "object.append_component_list_entry" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Append List Entry (Object)" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    path: bpy.props.CollectionProperty(type=PathKeyGroup, name="Append Path")
+
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, "object") and context.object is not None
+
+    def execute(self, context):
+        append_component_list_entry_data(context, context.object, self.path)
+        return {'FINISHED'}
+
+class AppendComponentListEntryOnMesh(bpy.types.Operator):
+    """Append a component on the selected mesh"""
+    bl_idname = "mesh.append_component_list_entry" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Append List Entry (Mesh)" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    path: bpy.props.CollectionProperty(type=PathKeyGroup, name="Append Path")
+
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, "mesh") and context.mesh is not None
+
+    def execute(self, context):
+        append_component_list_entry_data(context, context.mesh, self.path)
+        return {'FINISHED'}
+
+class AppendComponentListEntryOnMaterial(bpy.types.Operator):
+    """Append a component on the selected material"""
+    bl_idname = "material.append_component_list_entry" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Append List Entry (Material)" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    path: bpy.props.CollectionProperty(type=PathKeyGroup, name="Append Path")
+
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, "material") and context.material is not None
+
+    def execute(self, context):
+        append_component_list_entry_data(context, context.material, self.path)
+        return {'FINISHED'}
+
+class AppendComponentListEntryOnScene(bpy.types.Operator):
+    """Append a component on the selected scene"""
+    bl_idname = "scene.append_component_list_entry" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Append List Entry (Scene)" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    path: bpy.props.CollectionProperty(type=PathKeyGroup, name="Append Path")
+
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, "scene") and context.scene is not None
+
+    def execute(self, context):
+        append_component_list_entry_data(context, context.scene, self.path)
+        return {'FINISHED'}
+
+class AppendComponentListEntryOnLight(bpy.types.Operator):
+    """Append a component on the selected light"""
+    bl_idname = "light.append_component_list_entry" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Append List Entry (Light)" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    path: bpy.props.CollectionProperty(type=PathKeyGroup, name="Append Path")
+
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, "light") and context.light is not None
+
+    def execute(self, context):
+        append_component_list_entry_data(context, context.light, self.path)
+        return {'FINISHED'}
+
+class AppendComponentListEntryOnCollection(bpy.types.Operator):
+    """Append a component on the selected collection"""
+    bl_idname = "collection.append_component_list_entry" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Append List Entry (Collection)" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    path: bpy.props.CollectionProperty(type=PathKeyGroup, name="Append Path")
+
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, "collection") and context.collection is not None
+
+    def execute(self, context):
+        append_component_list_entry_data(context, context.collection, self.path)
+        return {'FINISHED'}
+
+class AppendComponentListEntryOnBone(bpy.types.Operator):
+    """Append a component on the selected bone"""
+    bl_idname = "bone.append_component_list_entry" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Append List Entry (Bone)" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    path: bpy.props.CollectionProperty(type=PathKeyGroup, name="Append Path")
+
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, "bone") and context.bone is not None
+
+    def execute(self, context):
+        append_component_list_entry_data(context, context.bone, self.path)
+        return {'FINISHED'}
+    
+###
+def append_component_list_entry_data(context, obj, path):
+    """
+    Removing data is super generic, the only difference is where we're removing it.
+    This is basically the same concept as Custom Properties which don't care what object they're on.
+    """
+
+    cur = obj.skein_two[obj.active_component_index]
+    cur = getattr(cur, hash_over_64(cur.selected_type_path))
+    
+    for key in path:
+        if key.is_index: #TODO: currently assumes only 'int' indices. 
+                         # This could be extended to dicts/maps by adding more cases for the different key types
+            cur = cur[int(key.value)]
+        else:
+            cur = getattr(cur, key.value)
+    cur.add()
+
+    # blender uses strings to indicate when operation is done
+    return {'FINISHED'}
+
+classes = (
+    AppendComponentListEntryOnObject,
+    AppendComponentListEntryOnMesh,
+    AppendComponentListEntryOnMaterial,
+    AppendComponentListEntryOnScene,
+    AppendComponentListEntryOnLight,
+    AppendComponentListEntryOnCollection,
+    AppendComponentListEntryOnBone,
+)
+
+register, unregister = bpy.utils.register_classes_factory(classes)

--- a/extension/op_registry_loading.py
+++ b/extension/op_registry_loading.py
@@ -244,7 +244,6 @@ def process_registry(context, registry):
                 else:
                     fake_component_enum_annotations[maybe_hashed_type_path] = property_group_or_property
 
-
         except Exception as e:
             if debug:
                 print("failed to make_property for: ", type_path)

--- a/extension/op_remove_component_list_entry.py
+++ b/extension/op_remove_component_list_entry.py
@@ -1,0 +1,146 @@
+import bpy
+from .property_groups import hash_over_64, PathKeyGroup
+
+class RemoveComponentListEntryOnObject(bpy.types.Operator):
+    """Remove a component on the selected object"""
+    bl_idname = "object.remove_component_list_entry" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Remove List Entry (Object)" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    path: bpy.props.CollectionProperty(type=PathKeyGroup, name="Remove Path")
+
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, "object") and context.object is not None
+
+    def execute(self, context):
+        remove_component_list_entry_data(context, context.object, self.path)
+        return {'FINISHED'}
+
+class RemoveComponentListEntryOnMesh(bpy.types.Operator):
+    """Remove a component on the selected mesh"""
+    bl_idname = "mesh.remove_component_list_entry" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Remove List Entry (Mesh)" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    path: bpy.props.CollectionProperty(type=PathKeyGroup, name="Remove Path")
+
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, "mesh") and context.mesh is not None
+
+    def execute(self, context):
+        remove_component_list_entry_data(context, context.mesh, self.path)
+        return {'FINISHED'}
+
+class RemoveComponentListEntryOnMaterial(bpy.types.Operator):
+    """Remove a component on the selected material"""
+    bl_idname = "material.remove_component_list_entry" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Remove List Entry (Material)" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    path: bpy.props.CollectionProperty(type=PathKeyGroup, name="Remove Path")
+
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, "material") and context.material is not None
+
+    def execute(self, context):
+        remove_component_list_entry_data(context, context.material, self.path)
+        return {'FINISHED'}
+
+class RemoveComponentListEntryOnScene(bpy.types.Operator):
+    """Remove a component on the selected scene"""
+    bl_idname = "scene.remove_component_list_entry" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Remove List Entry (Scene)" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    path: bpy.props.CollectionProperty(type=PathKeyGroup, name="Remove Path")
+
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, "scene") and context.scene is not None
+
+    def execute(self, context):
+        remove_component_list_entry_data(context, context.scene, self.path)
+        return {'FINISHED'}
+
+class RemoveComponentListEntryOnLight(bpy.types.Operator):
+    """Remove a component on the selected light"""
+    bl_idname = "light.remove_component_list_entry" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Remove List Entry (Light)" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    path: bpy.props.CollectionProperty(type=PathKeyGroup, name="Remove Path")
+    
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, "light") and context.light is not None
+
+    def execute(self, context):
+        remove_component_list_entry_data(context, context.light, self.path)
+        return {'FINISHED'}
+
+class RemoveComponentListEntryOnCollection(bpy.types.Operator):
+    """Remove a component on the selected collection"""
+    bl_idname = "collection.remove_component_list_entry" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Remove List Entry (Collection)" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    path: bpy.props.CollectionProperty(type=PathKeyGroup, name="Remove Path")
+    
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, "collection") and context.collection is not None
+
+    def execute(self, context):
+        remove_component_list_entry_data(context, context.collection, self.path)
+        return {'FINISHED'}
+
+class RemoveComponentListEntryOnBone(bpy.types.Operator):
+    """Remove a component on the selected bone"""
+    bl_idname = "bone.remove_component_list_entry" # unique identifier. first word is required by extensions review team to be from a specific set of words
+    bl_label = "Remove List Entry (Bone)" # Shows up in the UI
+    bl_options = {'REGISTER', 'UNDO'} # enable undo (which we might not need)
+
+    path: bpy.props.CollectionProperty(type=PathKeyGroup, name="Remove Path")
+    
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context, "bone") and context.bone is not None
+
+    def execute(self, context):
+        remove_component_list_entry_data(context, context.bone)
+        return {'FINISHED'}
+    
+###
+def remove_component_list_entry_data(context, obj, path):
+    """
+    Removing data is super generic, the only difference is where we're removing it.
+    This is basically the same concept as Custom Properties which don't care what object they're on.
+    """
+    
+    cur = obj.skein_two[obj.active_component_index]
+    cur = getattr(cur, hash_over_64(cur.selected_type_path))
+    
+    for key in path[:-1]:
+        if key.is_index:
+            cur = cur[int(key.value)]
+        else:
+            cur = getattr(cur, key.value)
+    cur.remove(int(path[-1].value))
+
+    # blender uses strings to indicate when operation is done
+    return {'FINISHED'}
+
+classes = (
+    RemoveComponentListEntryOnObject,
+    RemoveComponentListEntryOnMesh,
+    RemoveComponentListEntryOnMaterial,
+    RemoveComponentListEntryOnScene,
+    RemoveComponentListEntryOnLight,
+    RemoveComponentListEntryOnCollection,
+    RemoveComponentListEntryOnBone,
+)
+
+register, unregister = bpy.utils.register_classes_factory(classes)

--- a/extension/property_groups.py
+++ b/extension/property_groups.py
@@ -36,10 +36,9 @@ def hash_type_path(data):
 # cause classes to fail to register
 # TODO: could this be a getter on ComponentContainer?
 def hash_over_64(type_path):
-    maybe_hashed_type_path = type_path
-    if len(type_path) > 63:
-        maybe_hashed_type_path = hash_type_path(type_path)
-    
+    maybe_hashed_type_path = capitalize_path(type_path)
+    if len(maybe_hashed_type_path) > 63:
+        maybe_hashed_type_path = hash_type_path(maybe_hashed_type_path)
     return maybe_hashed_type_path
 
 def make_property(
@@ -155,14 +154,14 @@ def make_property(
                     if "core::option::Option<" in type_path and component["modulePath"] == "core::option" and "Option<" in component["shortPath"]:
                         # add this struct type to the skein_property_groups so it 
                         # can be accessed elsewhere by type_path
-                        skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+                        skein_property_groups[type_path] = type(hash_over_64(type_path), (ComponentData,), {
                             '__annotations__': annotations,
                             "is_core_option": True
                         })
                     else:
                         # add this struct type to the skein_property_groups so it 
                         # can be accessed elsewhere by type_path
-                        skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+                        skein_property_groups[type_path] = type(hash_over_64(type_path), (ComponentData,), {
                             '__annotations__': annotations,
                         })
 
@@ -189,16 +188,15 @@ def make_property(
                     item_type_path
                 )
             if item_property is not None:
-                print(f"{item_type_path}: {item_property} is class: {inspect.isclass(item_property)}")
                 property = bpy.props.CollectionProperty(type=item_property)
-                skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+                skein_property_groups[type_path] = type(hash_over_64(type_path), (ComponentData,), {
                     '__annotations__': {
                         "list_wrapper": property
                     },
                     'is_list': True,
                 })
             else:
-                skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+                skein_property_groups[type_path] = type(hash_over_64(type_path), (ComponentData,), {
                     '__annotations__': {
                         "force_default": "list"
                     },
@@ -208,8 +206,9 @@ def make_property(
                     skein_property_groups[type_path]
                 )
             except: #fallback to default empty list in case some item type is invalid
-                print(f"registration failed for item_type: {item_type_path}")
-                skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+                if debug:
+                    print(f"registration failed for item_type: {item_type_path}")
+                skein_property_groups[type_path] = type(hash_over_64(type_path), (ComponentData,), {
                     '__annotations__': {
                         "force_default": "list"
                     },
@@ -219,7 +218,7 @@ def make_property(
                 )
             return skein_property_groups[type_path]
         case "Map":
-            skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+            skein_property_groups[type_path] = type(hash_over_64(type_path), (ComponentData,), {
                 '__annotations__': {},
                 # force_default bypasses recursion and forces
                 # an empty data structure in the output
@@ -240,14 +239,14 @@ def make_property(
                 )
             if item_property is not None:
                 property = bpy.props.CollectionProperty(type=item_property)
-                skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+                skein_property_groups[type_path] = type(hash_over_64(type_path), (ComponentData,), {
                     '__annotations__': {
                         "list_wrapper": property
                     },
                     'is_list': True,
                 })
             else:
-                skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+                skein_property_groups[type_path] = type(hash_over_64(type_path), (ComponentData,), {
                     '__annotations__': {
                         "force_default": "list"
                     },
@@ -257,7 +256,7 @@ def make_property(
                     skein_property_groups[type_path]
                 )
             except: #fallback to default empty list in case some item type is invalid
-                skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+                skein_property_groups[type_path] = type(hash_over_64(type_path), (ComponentData,), {
                     '__annotations__': {
                         "force_default": "list"
                     },
@@ -289,7 +288,7 @@ def make_property(
             
             # add this struct type to the skein_property_groups so it 
             # can be accessed elsewhere by type_path
-            t = hash_type_path(capitalize_path(type_path))
+            t = hash_over_64(type_path)
             skein_property_groups[type_path] = type(t, (ComponentData,), {
                 '__annotations__': annotations,
                 'type_override': type_path
@@ -332,7 +331,7 @@ def make_property(
                     else:
                         annotations[str(i)] = property
 
-                t = hash_type_path(capitalize_path(type_path))
+                t = hash_over_64(type_path)
                 skein_property_groups[type_path] = type(t, (ComponentData,), {
                     '__annotations__': annotations,
                     'tuple_length': len(component["prefixItems"]),
@@ -375,7 +374,7 @@ def make_property(
                     else:
                         annotations[str(i)] = property
 
-                t = hash_type_path(capitalize_path(type_path))
+                t = hash_over_64(type_path)
                 skein_property_groups[type_path] = type(t, (ComponentData,), {
                     '__annotations__': annotations,
                     'tuple_length': len(component["prefixItems"]),
@@ -391,7 +390,7 @@ def make_property(
             value_prop = make_value_property(component, type_path, skein_property_groups, debug)
             if value_prop is None:
                 return
-            t = hash_type_path(capitalize_path(type_path))
+            t = hash_over_64(type_path)
             annotations['inner'] = value_prop
             value_wrapper = type(t, (ComponentData,), {
                     '__annotations__': annotations,

--- a/extension/property_groups.py
+++ b/extension/property_groups.py
@@ -189,6 +189,7 @@ def make_property(
                     item_type_path
                 )
             if item_property is not None:
+                print(f"{item_type_path}: {item_property} is class: {inspect.isclass(item_property)}")
                 property = bpy.props.CollectionProperty(type=item_property)
                 skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
                     '__annotations__': {
@@ -207,6 +208,7 @@ def make_property(
                     skein_property_groups[type_path]
                 )
             except: #fallback to default empty list in case some item type is invalid
+                print(f"registration failed for item_type: {item_type_path}")
                 skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
                     '__annotations__': {
                         "force_default": "list"
@@ -263,7 +265,6 @@ def make_property(
                 bpy.utils.register_class(
                     skein_property_groups[type_path]
                 )
-
             return skein_property_groups[type_path]
         case "Struct":
             annotations = {}
@@ -386,12 +387,20 @@ def make_property(
                 )
                 return skein_property_groups[type_path]
         case "Value":
+            annotations = {}
             value_prop = make_value_property(component, type_path, skein_property_groups, debug)
             if value_prop is None:
                 return
-            skein_property_groups[type_path] = value_prop
+            t = hash_type_path(capitalize_path(type_path))
+            annotations['inner'] = value_prop
+            value_wrapper = type(t, (ComponentData,), {
+                    '__annotations__': annotations,
+                    'is_value': True,
+                    'type_override': type_path
+                })
+            skein_property_groups[type_path] = value_wrapper
             bpy.utils.register_class(
-                skein_property_groups[type_path]
+                skein_property_groups[type_path]    
             )
             return skein_property_groups[type_path]
         # If an exact match is not confirmed, this last case will be used if provided

--- a/extension/property_groups.py
+++ b/extension/property_groups.py
@@ -4,6 +4,11 @@ import bpy # type: ignore
 import re
 import inspect
 
+# tracks where the editor is currently at while drawing, so the operators for updating lists can work properly
+class PathKeyGroup(bpy.types.PropertyGroup):
+    value: bpy.props.StringProperty(name="Value")
+    is_index: bpy.props.BoolProperty(name="Is_Index")
+
 # the class we use to create PropertyGroups dynamically
 class ComponentData(bpy.types.PropertyGroup):
     type_path: bpy.props.StringProperty(name="type_path", default="Unknown") # type: ignore
@@ -176,16 +181,40 @@ def make_property(
                         print("unknown Enum type: ", component["type"], "\n  ", type_path)
                     return
         case "List":
-            # Vecs/Lists are not well handled yet
-            skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
-                '__annotations__': {},
-                # force_default bypasses recursion and forces
-                # an empty data structure in the output
-                "force_default": "list"
-            })
-            bpy.utils.register_class(
-                skein_property_groups[type_path]
-            )
+            item_type_path = component["items"]["type"]["$ref"]
+            
+            item_property = make_property(
+                    skein_property_groups,
+                    registry,
+                    item_type_path
+                )
+            if item_property is not None:
+                property = bpy.props.CollectionProperty(type=item_property)
+                skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+                    '__annotations__': {
+                        "list_wrapper": property
+                    },
+                    'is_list': True,
+                })
+            else:
+                skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+                    '__annotations__': {
+                        "force_default": "list"
+                    },
+                })
+            try:
+                bpy.utils.register_class(
+                    skein_property_groups[type_path]
+                )
+            except: #fallback to default empty list in case some item type is invalid
+                skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+                    '__annotations__': {
+                        "force_default": "list"
+                    },
+                })
+                bpy.utils.register_class(
+                    skein_property_groups[type_path]
+                )
             return skein_property_groups[type_path]
         case "Map":
             skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
@@ -200,15 +229,41 @@ def make_property(
             return skein_property_groups[type_path]
         case "Set":
             # Handle Sets in the same way as Vecs/Lists
-            skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
-                '__annotations__': {},
-                # force_default bypasses recursion and forces
-                # an empty data structure in the output
-                "force_default": "list"
-            })
-            bpy.utils.register_class(
-                skein_property_groups[type_path]
-            )
+            item_type_path = component["items"]["type"]["$ref"]
+            
+            item_property = make_property(
+                    skein_property_groups,
+                    registry,
+                    item_type_path
+                )
+            if item_property is not None:
+                property = bpy.props.CollectionProperty(type=item_property)
+                skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+                    '__annotations__': {
+                        "list_wrapper": property
+                    },
+                    'is_list': True,
+                })
+            else:
+                skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+                    '__annotations__': {
+                        "force_default": "list"
+                    },
+                })
+            try:
+                bpy.utils.register_class(
+                    skein_property_groups[type_path]
+                )
+            except: #fallback to default empty list in case some item type is invalid
+                skein_property_groups[type_path] = type(hash_type_path(capitalize_path(type_path)), (ComponentData,), {
+                    '__annotations__': {
+                        "force_default": "list"
+                    },
+                })
+                bpy.utils.register_class(
+                    skein_property_groups[type_path]
+                )
+
             return skein_property_groups[type_path]
         case "Struct":
             annotations = {}
@@ -230,7 +285,7 @@ def make_property(
                         )
                     else:
                         annotations[key] = property
-
+            
             # add this struct type to the skein_property_groups so it 
             # can be accessed elsewhere by type_path
             t = hash_type_path(capitalize_path(type_path))
@@ -258,9 +313,35 @@ def make_property(
                 )
                 return skein_property_groups[type_path]
             else:
-                if debug:
-                    print("Tuple is unimplemented in make_property for lengths longer than 1 element: ", type_path)
-                return
+                annotations = {}
+                for i, prefix_item in enumerate(component["prefixItems"]):
+                    prefix_item_type_path = prefix_item["type"]["$ref"]
+
+                    property = make_property(
+                        skein_property_groups,
+                        registry,
+                        prefix_item_type_path
+                    )
+
+                    if inspect.isclass(property):
+                        annotations[str(i)] = bpy.props.PointerProperty(
+                            type=property,
+                            override={"LIBRARY_OVERRIDABLE"},
+                        )
+                    else:
+                        annotations[str(i)] = property
+
+                t = hash_type_path(capitalize_path(type_path))
+                skein_property_groups[type_path] = type(t, (ComponentData,), {
+                    '__annotations__': annotations,
+                    'tuple_length': len(component["prefixItems"]),
+                    'is_tuple': True,
+                    'type_override': type_path
+                })
+                bpy.utils.register_class(
+                    skein_property_groups[type_path]
+                )
+                return skein_property_groups[type_path]
         case "TupleStruct":
             # single element tuple struct is a special case
             # because the reflection format treats it as a
@@ -276,12 +357,52 @@ def make_property(
                 )
                 return skein_property_groups[type_path]
             else:
-                if debug:
-                    print("TupleStruct is unimplemented in make_property for lengths longer than 1 element: ", type_path)
-                return
+                annotations = {}
+                for i, prefix_item in enumerate(component["prefixItems"]):
+                    prefix_item_type_path = prefix_item["type"]["$ref"]
+                    property = make_property(
+                        skein_property_groups,
+                        registry,
+                        prefix_item_type_path
+                    )
+                    
+                    if inspect.isclass(property):
+                        annotations[str(i)] = bpy.props.PointerProperty(
+                            type=property,
+                            override={"LIBRARY_OVERRIDABLE"},
+                        )
+                    else:
+                        annotations[str(i)] = property
+
+                t = hash_type_path(capitalize_path(type_path))
+                skein_property_groups[type_path] = type(t, (ComponentData,), {
+                    '__annotations__': annotations,
+                    'tuple_length': len(component["prefixItems"]),
+                    'is_tuple': True,
+                    'type_override': type_path
+                })
+                bpy.utils.register_class(
+                    skein_property_groups[type_path]
+                )
+                return skein_property_groups[type_path]
         case "Value":
-            # print("- component[type]:  ", component["type"])
-            match component["type"]:
+            value_prop = make_value_property(component, type_path, skein_property_groups, debug)
+            if value_prop is None:
+                return
+            skein_property_groups[type_path] = value_prop
+            bpy.utils.register_class(
+                skein_property_groups[type_path]
+            )
+            return skein_property_groups[type_path]
+        # If an exact match is not confirmed, this last case will be used if provided
+        case _:
+            if debug:
+                print("unhandled kind:", component["kind"], "\n  ", type_path)
+            return "Something's wrong with the world"
+
+# creates or gets a property for primitive data types. This does NOT register with bpy.utils.register_class
+def make_value_property(component, type_path, skein_property_groups, debug):
+    match component["type"]:
                 case "boolean":
                     return bpy.props.BoolProperty(
                         override={"LIBRARY_OVERRIDABLE"}
@@ -390,6 +511,7 @@ def make_property(
                         print("component: ", component)
                     match component["typePath"]:
                         case "core::num::NonZeroU8":
+
                             return bpy.props.IntProperty(
                                 min=0,
                                 max=255,
@@ -511,8 +633,3 @@ def make_property(
                     if debug:
                         print("unhandled type: ", component["type"])
                     return
-        # If an exact match is not confirmed, this last case will be used if provided
-        case _:
-            if debug:
-                print("unhandled kind:", component["kind"], "\n  ", type_path)
-            return "Something's wrong with the world"

--- a/extension/skein_panel.py
+++ b/extension/skein_panel.py
@@ -217,7 +217,6 @@ def render_two(layout, context, context_key, execute_mode, property_path = [], l
     if context_key not in context:
         layout.label(text=context_key + " not in context")
         return
-    
 
     # The current PropertyGroup we're working with
     obj = getattr(context, context_key)
@@ -281,6 +280,13 @@ def render_two(layout, context, context_key, execute_mode, property_path = [], l
                     layout.prop(obj, value)
         return
 
+    try:
+        if obj.is_value:
+            layout.prop(obj, "inner", text=f"{property_path[-1]['value']}")
+            return
+    except AttributeError:
+        pass
+
     # attempt to handle any type overrides, like glam::Vec3
     # Currently all of the types here are *also* hardcoded 
     # because their serialization format differs from their
@@ -290,33 +296,33 @@ def render_two(layout, context, context_key, execute_mode, property_path = [], l
     try:
         match obj.type_override:
             case "glam::Vec2" | "glam::DVec2" | "glam::I8Vec2" | "glam::U8Vec2" | "glam::I16Vec2" | "glam::U16Vec2" | "glam::IVec2" | "glam::UVec2" | "glam::I64Vec2" | "glam::U64Vec2" | "glam::BVec2":
-                col = layout.column(align=True)
-                col.label(text=context_key + ":")
-                col.prop(obj, "x")
-                col.prop(obj, "y")
+                row = layout.row(align=True)
+                row.label(text=context_key + ":")
+                row.prop(obj.x, "inner", text="x")
+                row.prop(obj.y, "inner", text="y")
                 return
             case "glam::Vec3" | "glam::Vec3A" | "glam::DVec3" | "glam::I8Vec3" | "glam::U8Vec3" | "glam::I16Vec3" | "glam::U16Vec3" | "glam::IVec3" | "glam::UVec3" | "glam::I64Vec3" | "glam::U64Vec3" | "glam::BVec3":
-                col = layout.column(align=True)
-                col.label(text=context_key + ":")
-                col.prop(obj, "x")
-                col.prop(obj, "y")
-                col.prop(obj, "z")
+                row = layout.row(align=True)
+                row.label(text=context_key + ":")
+                row.prop(obj.x, "inner", text="x")
+                row.prop(obj.y, "inner", text="y")
+                row.prop(obj.z, "inner", text="z")
                 return
             case "glam::Vec4" | "glam::DVec4" | "glam::I8Vec4" | "glam::U8Vec4" | "glam::I16Vec4" | "glam::U16Vec4" | "glam::IVec4" | "glam::UVec4" | "glam::I64Vec4" | "glam::U64Vec4" | "glam::BVec4":
-                col = layout.column(align=True)
-                col.label(text=context_key + ":")
-                col.prop(obj, "x")
-                col.prop(obj, "y")
-                col.prop(obj, "z")
-                col.prop(obj, "w")
+                row = layout.row(align=True)
+                row.label(text=context_key + ":")
+                row.prop(obj.x, "inner", text="x")
+                row.prop(obj.y, "inner", text="y")
+                row.prop(obj.z, "inner", text="z")
+                row.prop(obj.w, "inner", text="w")
                 return
             case "glam::Quat" | "glam::DQuat":
-                col = layout.column(align=True)
-                col.label(text=context_key + ":")
-                col.prop(obj, "x")
-                col.prop(obj, "y")
-                col.prop(obj, "z")
-                col.prop(obj, "w")
+                row = layout.row(align=True)
+                row.label(text=context_key + ":")
+                row.prop(obj.x, "inner", text="x")
+                row.prop(obj.y, "inner", text="y")
+                row.prop(obj.z, "inner", text="z")
+                row.prop(obj.w, "inner", text="w")
                 return
             
     except AttributeError:
@@ -344,13 +350,28 @@ def render_two(layout, context, context_key, execute_mode, property_path = [], l
     except AttributeError:
         pass
 
+
+
     # No more special handling, just take the keys and values that are
     # in the annotations, and plug them into the object
     for key, value in annotations.items():
         sub_property_path = property_path + [{"value": key, "is_index": False}]            
+
+
         try:
             if "PointerProperty" == value.function.__name__:
                 next_type = getattr(obj, key)
+
+                try:
+                    if next_type.is_value:
+                        try:
+                            layout.prop(next_type, "inner", text=key)
+                        except:
+                            pass
+                        continue
+                except AttributeError:
+                    pass
+
                 match next_type.type_override:
                     case "glam::Vec2" | "glam::DVec2" | "glam::I8Vec2" | "glam::U8Vec2" | "glam::I16Vec2" | "glam::U16Vec2" | "glam::IVec2" | "glam::UVec2" | "glam::I64Vec2" | "glam::U64Vec2" | "glam::BVec2":
                         render_two(layout, obj, key, execute_mode, sub_property_path)

--- a/extension/skein_panel.py
+++ b/extension/skein_panel.py
@@ -1,8 +1,9 @@
 import bpy # type: ignore
 import json
 import inspect
+import copy
 
-from .property_groups import hash_over_64
+from .property_groups import hash_over_64, PathKeyGroup
 
 # ---------------------------------- #
 #  Skein Panel for adding components #
@@ -203,22 +204,26 @@ def draw_generic_panel(context, obj, layout, execute_mode, skein_preset_panel_id
 
             row = layout.row()
             row.separator()
-
+            
             if inspect.isclass(skein_property_groups[type_path]):
                 if hash_over_64(type_path) not in active_component_data:
                     layout.label(text=active_component_data.name + " has no data to edit")
                 else:
-                    render_two(layout, active_component_data, hash_over_64(type_path))
+                    render_two(layout, active_component_data, hash_over_64(type_path), execute_mode)
             else:
                 layout.prop(active_component_data, hash_over_64(type_path))
 
-def render_two(layout, context, context_key):
+def render_two(layout, context, context_key, execute_mode, property_path = [], list_idx = None):
     if context_key not in context:
         layout.label(text=context_key + " not in context")
         return
     
+
     # The current PropertyGroup we're working with
     obj = getattr(context, context_key)
+    if list_idx is not None:
+        obj = obj[list_idx]
+
 
     try:
         match obj.force_default:
@@ -247,7 +252,7 @@ def render_two(layout, context, context_key):
                 case "Some":
                     layout.separator(type="LINE")
                     if "PointerProperty" == annotations["Some"].function.__name__:
-                        render_two(layout, obj, "Some")
+                        render_two(layout, obj, "Some", execute_mode, property_path)
                     else:
                         layout.prop(obj, "Some")
             return
@@ -271,7 +276,7 @@ def render_two(layout, context, context_key):
             # recurse down into the enum
             case value:
                 if "PointerProperty" == annotations[value].function.__name__:
-                    render_two(layout.box(), obj, value)
+                    render_two(layout.box(), obj, value, execute_mode, property_path)
                 else:
                     layout.prop(obj, value)
         return
@@ -313,129 +318,56 @@ def render_two(layout, context, context_key):
                 col.prop(obj, "z")
                 col.prop(obj, "w")
                 return
-    #         case "glam::Mat2" | "glam::DMat2":
-    #             x_axis = getattr(obj, "x_axis")
-    #             y_axis = getattr(obj, "y_axis")
-                
-    #             return [
-    #                 getattr(x_axis, "x"),
-    #                 getattr(x_axis, "y"),
-
-    #                 getattr(y_axis, "x"),
-    #                 getattr(y_axis, "y"),
-    #             ]
-
-    #         case "glam::Mat3" | "glam::Mat3A" | "glam::DMat3":
-    #             x_axis = getattr(obj, "x_axis")
-    #             y_axis = getattr(obj, "y_axis")
-    #             z_axis = getattr(obj, "z_axis")
-                
-    #             return [
-    #                 getattr(x_axis, "x"),
-    #                 getattr(x_axis, "y"),
-    #                 getattr(x_axis, "z"),
-
-    #                 getattr(y_axis, "x"),
-    #                 getattr(y_axis, "y"),
-    #                 getattr(y_axis, "z"),
-
-    #                 getattr(z_axis, "x"),
-    #                 getattr(z_axis, "y"),
-    #                 getattr(z_axis, "z"),
-    #             ]
-    #         case "glam::Mat4" | "glam::DMat4":
-    #             x_axis = getattr(obj, "x_axis")
-    #             y_axis = getattr(obj, "y_axis")
-    #             z_axis = getattr(obj, "z_axis")
-    #             w_axis = getattr(obj, "w_axis")
-                
-    #             return [
-    #                 getattr(x_axis, "x"),
-    #                 getattr(x_axis, "y"),
-    #                 getattr(x_axis, "z"),
-    #                 getattr(x_axis, "w"),
-
-    #                 getattr(y_axis, "x"),
-    #                 getattr(y_axis, "y"),
-    #                 getattr(y_axis, "z"),
-    #                 getattr(y_axis, "w"),
-
-    #                 getattr(z_axis, "x"),
-    #                 getattr(z_axis, "y"),
-    #                 getattr(z_axis, "z"),
-    #                 getattr(z_axis, "w"),
-
-    #                 getattr(w_axis, "x"),
-    #                 getattr(w_axis, "y"),
-    #                 getattr(w_axis, "z"),
-    #                 getattr(w_axis, "w"),
-    #             ]
-  
-    #         case "glam::Affine2" | "glam::DAffine2":
-    #             mat = getattr(obj, "matrix2")
-    #             x_axis = getattr(mat, "x_axis")
-    #             y_axis = getattr(mat, "y_axis")
-    #             translation = getattr(obj, "translation")
-                
-    #             return [
-    #                 getattr(x_axis, "x"),
-    #                 getattr(x_axis, "y"),
-    #                 getattr(y_axis, "x"),
-    #                 getattr(y_axis, "y"),
-    #                 getattr(translation, "x"),
-    #                 getattr(translation, "y"),
-    #             ]
-    #         case "glam::Affine3A" | "glam::DAffine3":
-    #             mat = getattr(obj, "matrix3")
-    #             x_axis = getattr(mat, "x_axis")
-    #             y_axis = getattr(mat, "y_axis")
-    #             z_axis = getattr(mat, "z_axis")
-    #             translation = getattr(obj, "translation")
-                
-    #             return [
-    #                 getattr(x_axis, "x"),
-    #                 getattr(x_axis, "y"),
-    #                 getattr(x_axis, "z"),
-    #                 getattr(y_axis, "x"),
-    #                 getattr(y_axis, "y"),
-    #                 getattr(y_axis, "z"),
-    #                 getattr(z_axis, "x"),
-    #                 getattr(z_axis, "y"),
-    #                 getattr(z_axis, "z"),
-    #                 getattr(translation, "x"),
-    #                 getattr(translation, "y"),
-    #                 getattr(translation, "z"),
-    #             ]
             
     except AttributeError:
         # Not all PropertyGroups have the type_override attribute, so
         # this is a common failure case that doesn't actually mean failure
         pass
+    
+    # Handle lists by traversing into the inner 'list_wrapper' 
+    # property and drawing all contained elements individually
+    try:
+        if obj.is_list:
+            sub_property_path = property_path + [{"value": "list_wrapper", "is_index": False}]
+            for i, item in enumerate(getattr(obj, "list_wrapper")):
+                indexed_sub_property_path = sub_property_path + [{"value": f"{i}", "is_index": True}]
+                row = layout.row()
+                row.label(text=f"Element {i}:")
+                remove_props = row.operator(operator=f"{execute_mode}.remove_component_list_entry", text="remove")
+                remove_props["path"] = indexed_sub_property_path
+
+                render_two(layout.box(), obj, "list_wrapper", execute_mode, indexed_sub_property_path, i)
+
+            append_props = layout.operator(operator=f"{execute_mode}.append_component_list_entry", text="add")
+            append_props["path"] = property_path + [{"value": "list_wrapper", "is_index": False}]
+            return
+    except AttributeError:
+        pass
 
     # No more special handling, just take the keys and values that are
     # in the annotations, and plug them into the object
     for key, value in annotations.items():
-        if "PointerProperty" == value.function.__name__:
-            try:
+        sub_property_path = property_path + [{"value": key, "is_index": False}]            
+        try:
+            if "PointerProperty" == value.function.__name__:
                 next_type = getattr(obj, key)
                 match next_type.type_override:
                     case "glam::Vec2" | "glam::DVec2" | "glam::I8Vec2" | "glam::U8Vec2" | "glam::I16Vec2" | "glam::U16Vec2" | "glam::IVec2" | "glam::UVec2" | "glam::I64Vec2" | "glam::U64Vec2" | "glam::BVec2":
-                        render_two(layout, obj, key)
+                        render_two(layout, obj, key, execute_mode, sub_property_path)
                     case "glam::Vec3" | "glam::Vec3A" | "glam::DVec3" | "glam::I8Vec3" | "glam::U8Vec3" | "glam::I16Vec3" | "glam::U16Vec3" | "glam::IVec3" | "glam::UVec3" | "glam::I64Vec3" | "glam::U64Vec3" | "glam::BVec3":
-                        render_two(layout, obj, key)
+                        render_two(layout, obj, key, execute_mode, sub_property_path)
                     case "glam::Vec4" | "glam::DVec4" | "glam::I8Vec4" | "glam::U8Vec4" | "glam::I16Vec4" | "glam::U16Vec4" | "glam::IVec4" | "glam::UVec4" | "glam::I64Vec4" | "glam::U64Vec4" | "glam::BVec4":
-                        render_two(layout, obj, key)
+                        render_two(layout, obj, key, execute_mode, sub_property_path)
                     case "glam::Quat" | "glam::DQuat":
-                        render_two(layout, obj, key)
+                        render_two(layout, obj, key, execute_mode, sub_property_path)
                     case _:
                         layout.label(text=key + ":")
-                        render_two(layout.box(), obj, key)
-            except AttributeError:
-                layout.label(text=key + ":")
-                render_two(layout.box(), obj, key)
-        else:
-            layout.prop(obj, key)
-    return
+                        render_two(layout.box(), obj, key, execute_mode, sub_property_path)
+            else:
+                layout.prop(obj, key)
+        except AttributeError:
+            layout.label(text=key + ":")
+            render_two(layout.box(), obj, key, execute_mode, sub_property_path)
 
 classes = (
     SkeinPanelObject,


### PR DESCRIPTION
relates to https://github.com/rust-adventure/skein/issues/31
Added support for lists and tuples. This should probably also work for sets, however I did not test that (yet).
dicts are not in scope for this PR since they require additional UI for the keys to work.

~~also lists of primitive types like f64, u32 etc. fail to register correctly.~~
~~This should probably be fixed before beginning to merge~~
Added a wrapper around *all* primitive types so CollectionProperty can properly use them
